### PR TITLE
Added defensive checks for non talkman message on transport channel

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -148,7 +148,17 @@ class CA {
 		 * Defensive checks for missing keys
 		 */
 
+		if (!seqId) {
+			console.log ({systemPayload},'no seqId, ignoring message')
+			return;
+		}
+
 		const reqPromise = this.reqPromises.get (seqId);
+
+		if (!reqPromise) {
+			console.log ({systemPayload}, 'no reqPromise corresponding to seqId, ignoring...')
+			return;
+		}
 
 		if (subType === 'ACK') {
 			reqPromise.resolve (userPayload);


### PR DESCRIPTION
Created PR against #1.
- Silently ignores non-talkman or non-coforming messages with a simple log